### PR TITLE
Remove deprecated Temporal service

### DIFF
--- a/d-websites/upload-ipfs.md
+++ b/d-websites/upload-ipfs.md
@@ -36,7 +36,7 @@ You can upload and attach your d-website to your domain in a single step from th
 </figure>
 
 :::info
-For websites that exceed the 20MB file limit, we recommend using a dedicated pinning service, such as [Pinata](https://pinata.cloud) or [Temporal](https://temporal.cloud).
+For websites that exceed the 20MB file limit, we recommend using a dedicated pinning service, such as [Pinata](https://pinata.cloud).
 :::
 
 :::success


### PR DESCRIPTION
## What/Why/How?

The docs currently reference an IPFS service called Temporal (not [that](https://temporal.io/) Temporal) which appears to have shut down in 2021 with no plans of returning. In addition, there are many more IPFS services available today that could take its place.

With the increasing number of new services, there is now a wide array of somewhat overlapping options that a developer could potentially choose between to integrate a website with their Unstoppable Domain.

I think it would be valuable to provide at least some information on a couple of the more prominent options so developers can get a sense for why they might want to try something aside from Pinata.

## Reference

> Temporal is shutting down and the hosted service will no longer be available. Going forward expect very little to no support on any github issues that are opened up.
> 
> [GitHub Issue - Temporal Is Shutting Down](https://github.com/RTradeLtd/Temporal/issues/489)

> Unfortunately we will be suspending our service until further notice and any existing services will be offline in the coming days. We are apologize for any inconvenience this may cause.
> 
> [Temporal Announcement Tweet](https://twitter.com/Temporalcloud/status/1347452505341317120)

## Alternatives

If you're looking to include other, more recent examples of IPFS services, here's a couple I think might be worth mentioning. In addition to just offering a pinning service, a lot of these blur the lines between hosting, pinning, storage, and IPFS gateways.

* [Fleek](https://fleek.co/)
* [Web3.Storage](https://web3.storage/docs/)
* [NFT.Storage](https://nft.storage/docs/how-to/retrieve/)
* [IPFS Cluster](https://cluster.ipfs.io/)
* [ChainSafe Storage](https://docs.storage.chainsafe.io/)
* [Filecoin](https://filecoin.io/)
* [Filebase](https://filebase.com/blog/introducing-support-for-ipfs-backed-by-decentralized-storage/)

And IMO (for what it's worth), while I haven't tried all of these, personally I enjoy using Fleek a lot. But that's just because I want everything to feel like the Jamstack all the time.

Having a guide for connecting a Fleek site to Unstoppable Domains similar to their [ENS](https://docs.fleek.co/domain-management/ens-domains/) or [HNS](https://docs.fleek.co/domain-management/hns-domains/) guides would be 🔥. Also [here's a fascinating little piece of related IPFS+Fleek history](https://discuss.ipfs.io/t/looking-for-devs-to-build-ipfs-websites/7990/5).

## [IPFS Pinning API](https://ipfs.github.io/pinning-services-api-spec/)

It might also be worth mentioning that IPFS is [trying to standardize around a specific IPFS Pinning API](https://github.com/ipfs/pinning-services-api-spec) which is being implemented in some form by [Pinata](https://docs.pinata.cloud/api-pinning/pinning-services-api), [NFT.Storage](https://nft.storage/docs/how-to/pinning-service/), and [Web3.Storage](https://web3.storage/docs/how-tos/pinning-services-api/).