### PR TITLE
[REG-814] - Update OpenAPI source for Resellers API

### DIFF
--- a/siteConfig.yaml
+++ b/siteConfig.yaml
@@ -14,7 +14,7 @@ linkChecker:
   options:
     CheckExternal: false
 oasDefinitions:
-  partner: https://api.redoc.ly/registry/bundle/unstoppable-domains/Reseller%20API/v2/openapi.yaml
+  partner: https://api.redocly.com/registry/bundle/unstoppable-domains/Reseller%20API/v2.1/openapi.yaml?branch=main
   login-unstoppable: https://api.redocly.com/registry/bundle/unstoppable-domains/Login%20API/v1/openapi.yaml
   resolution: https://api.redocly.com/registry/bundle/unstoppable-domains/Resolution%20API/v1/openapi.yaml?branch=root
   # add links to definitions in our API registry by using a fully qualified URL.


### PR DESCRIPTION
## What/Why/How?
Use website url as a source for OpenAPI specification for Resellers API v2 

- https://unstoppabledomains.com/api/v2/resellers/openapi.yaml 
- https://api.redocly.com/registry/bundle/unstoppable-domains/Reseller%20API/v2.1/openapi.yaml?branch=main

## Reference
https://linear.app/unstoppable-domains/issue/REG-814/move-api-v2-openapi-spec-into-main-repo

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
