### PR TITLE
npm instead of yarn in node-js-server-guide.md

### DIFF
--- a/login-with-unstoppable/login-integration-guides/node-js-server-guide.md
+++ b/login-with-unstoppable/login-integration-guides/node-js-server-guide.md
@@ -47,7 +47,7 @@ yarn add express-session express express-async-errors morgan
 ```
 
 ```shell npm
-yarn intall --save express-session express express-async-errors morgan
+npm install --save express-session express express-async-errors morgan
 ```
 
 ## Step 3: Setup @uauth/node Library


### PR DESCRIPTION


## What/Why/How?
yarn intall --save express-session express express-async-errors morgan //typo

npm install  --save express-session express express-async-errors morgan //correct

## Reference
[node-js-server-guide.md](https://docs.unstoppabledomains.com/login-with-unstoppable/login-integration-guides/node-js-server-guide/#step-2-install-the-uauthnode-library)

## Testing

## Screenshots (optional)

## Check yourself

- [ x] Code is linted
- [ x] Tested
- [ x] All new/updated code is covered with tests

## Security

- [ x] Security impact of change has been considered
- [ x] Code follows company security practices and guidelines
