### PR TITLE
Removing Erroneous Auth header line

### DIFF
--- a/partner/domain-actions-guides/return-action.md
+++ b/partner/domain-actions-guides/return-action.md
@@ -48,7 +48,6 @@ Here is an example of a request that you can use to create a domain action reque
 
 ```bash Request
 curl --location --request POST 'https://api.ud-sandbox.com/api/v2/resellers/{PARTNER_RESELLERID}/actions' \
---header 'Authorization: Bearer {SECRET_API_TOKEN}' \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "action": "Return",


### PR DESCRIPTION
## What/Why/How?

Partner API v2 Domain Actions do no t require Bearer tokens.  This PR removes an erroneous authorization header line from, the Return domain action example.

## Screenshots

Before:
<img width="1012" alt="Screenshot 2023-02-21 at 2 22 47 PM" src="https://user-images.githubusercontent.com/13068878/220439181-1286fdf5-bf2b-415a-825b-e12b9d17bc4e.png">

After:
<img width="904" alt="Screenshot 2023-02-21 at 2 23 21 PM" src="https://user-images.githubusercontent.com/13068878/220439294-a3cfdcd1-2b1f-42bf-a380-b9845550e049.png">


## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
