### PR TITLE
Removing whitespace for more active real estate

### DIFF
--- a/components/DeveloperSurvey.tsx
+++ b/components/DeveloperSurvey.tsx
@@ -2,16 +2,16 @@ import * as React from 'react';
 
 export function DeveloperSurvey() {
   return (
-    <div style={{ margin: '83.475px 0px' }}>
-      <div style={{ backgroundColor: '#0D67FE', color: '#FFFCF0', padding: '4rem', borderRadius: '1.5rem' }} align={ 'center' }>
+    <div className="margin-top-bottom-30">
+      <div style={{ backgroundColor: '#0D67FE', color: '#FFFCF0', padding: '4rem', borderRadius: '1.5rem', textAlign: 'center' }}>
         <h2 style={{ fontWeight: 600, fontSize: 31.5, marginTop: '0px' }}>
           Help us improve our products!
         </h2>
         <p style={{ lineHeight: '25px' }}>
           We're always looking for ways to improve how developers use and integrate our products into their applications. We'd love to hear about your experience to help us get better.
         </p>
-        <button data-Tf-Slider={ "uHPQyHO6" } data-Tf-Width={ 550 } data-Tf-Iframe-Props={ "title=Developer Research Survey" } data-Tf-Medium={ "snippet" } style={{ all: 'unset', display: 'inline-block', maxWidth: '100%', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', fontSize: '16px', borderRadius: '4px', padding: '10.5px 44px', fontWeight: '600', height: '35px', cursor: 'pointer', lineHeight: '35px', margin: 0, textDecoration: 'none', border: '2px solid #FFFCF0', margin: '0.5em 1em' }}>Take Our Developer Survey</button>
-        <button data-Tf-Slider={ "OC87toiF" } data-Tf-Width={ 550 } data-Tf-Iframe-Props={ "title=Developer Research Survey" } data-Tf-Medium={ "snippet" } style={{ all: 'unset', display: 'inline-block', maxWidth: '100%', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', fontSize: '16px', borderRadius: '4px', padding: '10.5px 44px', fontWeight: '600', height: '35px', cursor: 'pointer', lineHeight: '35px', margin: 0, textDecoration: 'none', border: '2px solid #FFFCF0', margin: '0.5em 1em' }}>Take Our Partner API Survey</button>
+        <button data-Tf-Slider={ "uHPQyHO6" } data-Tf-Width={ 550 } data-Tf-Iframe-Props={ "title=Developer Research Survey" } data-Tf-Medium={ "snippet" } style={{ all: 'unset', display: 'inline-block', maxWidth: '100%', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', fontSize: '16px', borderRadius: '4px', padding: '10.5px 44px', fontWeight: '600', height: '35px', cursor: 'pointer', lineHeight: '35px', textDecoration: 'none', border: '2px solid #FFFCF0', margin: '0.5em 1em 0.5em 1em' }}>Take Our Developer Survey</button>
+        <button data-Tf-Slider={ "OC87toiF" } data-Tf-Width={ 550 } data-Tf-Iframe-Props={ "title=Developer Research Survey" } data-Tf-Medium={ "snippet" } style={{ all: 'unset', display: 'inline-block', maxWidth: '100%', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', fontSize: '16px', borderRadius: '4px', padding: '10.5px 44px', fontWeight: '600', height: '35px', cursor: 'pointer', lineHeight: '35px', textDecoration: 'none', border: '2px solid #FFFCF0', margin: '0.5em 1em 0.5em 1em' }}>Take Our Partner API Survey</button>
       </div>
     </div>
   );

--- a/index.mdx
+++ b/index.mdx
@@ -27,9 +27,9 @@ export default LandingLayout;
 
 <NavBar location={props.location} standalone={false} />
 
-<Jumbotron className="jumbotron-padding-bottom-less">
-  <H1 className="h1-less-margin">Developer Documentation</H1>
-  <H2>Everything you need to build, customize, <br/>and integrate with Unstoppable Domains.</H2>
+<Jumbotron className="padding-top-bottom-20">
+  <H1 className="margin-top-bottom-20">Developer Documentation</H1>
+  <H2 className="margin-top-bottom-20">Everything you need to build, customize, <br/>and integrate with Unstoppable Domains.</H2>
   <Flex p={20} justifyContent="center">
      <Button variant="contained" size="xlarge" color="primary" to="getting-started/index.md">
       Get Started
@@ -37,27 +37,27 @@ export default LandingLayout;
   </Flex>
 </Jumbotron>
 <Box my={25}>
-  <SectionHeader className="h2-margin-top-bottom-less">
+  <SectionHeader className="margin-top-bottom-30 padding-top-bottom-10">
     <Emphasis>Browse By Product</Emphasis>
   </SectionHeader>
   <FlexSection justifyContent="space-around" flexWrap="wrap">
-    <WideTile to="developer-toolkit/index.md" header="Resolution">
+    <WideTile to="developer-toolkit/index.md" header="Resolution" className="margin-top-bottom-20">
         Resolve domain names
     </WideTile>
-    <WideTile to="login-with-unstoppable/index.md" header="Identity">
+    <WideTile to="login-with-unstoppable/index.md" header="Identity" className="margin-top-bottom-20">
         Build a universal Web3 login
     </WideTile>
-    <WideTile to="partner/index.md" header="Partner API">
+    <WideTile to="partner/index.md" header="Partner API" className="margin-top-bottom-20">
         Become a partner to generate revenue
     </WideTile>
-    <WideTile to="developer-toolkit/reference/smart-contracts/uns-smart-contracts.md" header="Smart Contracts">
+    <WideTile to="developer-toolkit/reference/smart-contracts/uns-smart-contracts.md" header="Smart Contracts" className="margin-top-bottom-20">
         UNS and CNS smart contracts
     </WideTile>
   </FlexSection>
-  <SectionHeader className="h2-margin-top-bottom-less">
+  <SectionHeader className="margin-top-bottom-30">
     Build your <Emphasis> application </Emphasis> today!
   </SectionHeader>
-  <FlexSection justifyContent="space-around" flexWrap="wrap">
+  <FlexSection justifyContent="space-around" flexWrap="wrap" className="padding-top-bottom-20">
     <ThinTile to="use-cases/index.mdx" icon={usecase} header="Use Cases">
         Review real life use cases along with potential solutions and
         direct links to Unstoppable integration guides, when applicable.

--- a/index.mdx
+++ b/index.mdx
@@ -27,8 +27,8 @@ export default LandingLayout;
 
 <NavBar location={props.location} standalone={false} />
 
-<Jumbotron>
-  <H1>Developer Documentation</H1>
+<Jumbotron className="jumbotron-padding-bottom-less">
+  <H1 className="h1-less-margin">Developer Documentation</H1>
   <H2>Everything you need to build, customize, <br/>and integrate with Unstoppable Domains.</H2>
   <Flex p={20} justifyContent="center">
      <Button variant="contained" size="xlarge" color="primary" to="getting-started/index.md">
@@ -37,7 +37,7 @@ export default LandingLayout;
   </Flex>
 </Jumbotron>
 <Box my={25}>
-  <SectionHeader>
+  <SectionHeader className="h2-margin-top-bottom-less">
     <Emphasis>Browse By Product</Emphasis>
   </SectionHeader>
   <FlexSection justifyContent="space-around" flexWrap="wrap">
@@ -54,7 +54,7 @@ export default LandingLayout;
         UNS and CNS smart contracts
     </WideTile>
   </FlexSection>
-  <SectionHeader>
+  <SectionHeader className="h2-margin-top-bottom-less">
     Build your <Emphasis> application </Emphasis> today!
   </SectionHeader>
   <FlexSection justifyContent="space-around" flexWrap="wrap">

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -174,3 +174,16 @@ figcaption {
         display: none!important;
     }
 }
+
+.h1-less-margin {
+    margin: 1.0em 0 0.25em 0 !important;
+}
+
+.h2-margin-top-bottom-less {
+    margin-top: 40px !important;
+    margin-bottom: 40px !important;
+}
+
+.jumbotron-padding-bottom-less {
+    padding-bottom: 72px !important;
+}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -175,15 +175,22 @@ figcaption {
     }
 }
 
-.h1-less-margin {
-    margin: 1.0em 0 0.25em 0 !important;
+.padding-top-bottom-10 {
+    padding-top: 10px !important;
+    padding-bottom: 10px !important;
 }
 
-.h2-margin-top-bottom-less {
-    margin-top: 40px !important;
-    margin-bottom: 40px !important;
+.padding-top-bottom-20 {
+    padding-top: 20px !important;
+    padding-bottom: 20px !important;
 }
 
-.jumbotron-padding-bottom-less {
-    padding-bottom: 72px !important;
+.margin-top-bottom-20 {
+    margin-top: 20px !important;
+    margin-bottom: 20px !important;
+}
+
+.margin-top-bottom-30 {
+    margin-top: 30px !important;
+    margin-bottom: 30px !important;
 }


### PR DESCRIPTION
## What/Why/How?

Making the landing page more densely populated, so we display more information above-the-fold.

## Screenshots (optional)

<img width="1690" alt="Screenshot 2023-02-28 at 11 11 10 AM" src="https://user-images.githubusercontent.com/13068878/221911392-996f4bc8-6cee-41db-9a3e-ca4fea26c9ed.png">

<img width="1687" alt="Screenshot 2023-02-28 at 11 12 01 AM" src="https://user-images.githubusercontent.com/13068878/221911594-9c1202cb-ee5c-4044-a9a6-0d524c979850.png">


## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
