### PR TITLE
Fix typo from Etherium to Ethereum

### DIFF
--- a/resolution/sidebars.yaml
+++ b/resolution/sidebars.yaml
@@ -17,7 +17,7 @@ pages:
     pages:
       - label: Records reference
         page: guides/records-reference.md
-      - label: Etherium providers
+      - label: Ethereum providers
         page: guides/ethereum-providers.md
       - group: Browser resolution (HTTP & IPFS)
         expanded: false


### PR DESCRIPTION
## What/Why/How?

Fixed a typo from "Etherium" to "Ethereum" in the Docs

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [X] Code is linted
- [X] Tested
- [X] All new/updated code is covered with tests

## Security

- [X] Security impact of change has been considered
- [X] Code follows company security practices and guidelines
