### PR TITLE
Add Messaging API v1 to Docs

### DIFF
--- a/identity/sidebars.yaml
+++ b/identity/sidebars.yaml
@@ -73,6 +73,8 @@ pages:
             page: ../openapi/loginref.page.yaml
           - label: Profile API
             page: ../openapi/profile-v1.page.yaml
+          - label: Messaging API
+            page: ../openapi/messaging-v1.page.yaml
           - label: Error codes
             page: api-reference/error-codes.md
       - group: SDKs and Libraries

--- a/openapi/messaging-v1.page.yaml
+++ b/openapi/messaging-v1.page.yaml
@@ -1,0 +1,15 @@
+type: reference-docs
+label: Messaging
+definitionId: messaging-v1
+settings:
+  pagination: none
+  showConsole: true
+  generateCodeSamples:
+    languages:
+      - lang: curl
+      - lang: Node.js
+      - lang: Python
+      - lang: Java
+      - lang: C#
+      - lang: PHP
+  hideDownloadButton: true

--- a/openapi/sidebars.yaml
+++ b/openapi/sidebars.yaml
@@ -5,5 +5,7 @@ pages:
     separatorLine: true
   - page: profile-v1.page.yaml
     separatorLine: true
+  - page: messaging-v1.page.yaml
+    separatorLine: true
   - page: loginref.page.yaml
     separatorLine: true

--- a/siteConfig.yaml
+++ b/siteConfig.yaml
@@ -19,6 +19,7 @@ oasDefinitions:
   profile-v1: https://api.redocly.com/registry/bundle/unstoppable-domains/Profile%20API/v1/openapi.yaml?branch=main
   login-unstoppable: https://api.redocly.com/registry/bundle/unstoppable-domains/Login%20API/v1/openapi.yaml
   resolution: https://api.redocly.com/registry/bundle/unstoppable-domains/Resolution%20API/v1/openapi.yaml?branch=root
+  messaging-v1: https://api.redocly.com/registry/bundle/unstoppable-domains/Messaging%20API/v1/openapi.yaml?branch=main
   # add links to definitions in our API registry by using a fully qualified URL.
 stylesheets:
   - ./static/css/main.css


### PR DESCRIPTION
Adds the profile API spec to the documentation pages. Modeled after changes in https://github.com/unstoppabledomains/dev-docs/pull/93

### Preview
<img width="1513" alt="image" src="https://github.com/unstoppabledomains/dev-docs/assets/21039114/97ccf620-c882-43b2-b204-e9b92f35632f">

