### PR TITLE
chore: Update API access guides for PAv3 and Resolution

### DIFF
--- a/domain-distribution-and-management/quickstart/retrieve-an-api-key.md
+++ b/domain-distribution-and-management/quickstart/retrieve-an-api-key.md
@@ -82,30 +82,12 @@ Request one of the following keys depending on your current usage. You **might**
 </figure>
 
 ### API Key
-Refer to [Partner API v3](https://docs.unstoppabledomains.com/openapi/partner/latest/) and [Domain Resolution API](https://docs.unstoppabledomains.com/openapi/resolution/) for supported use cases.
+Refer to [Partner API v3](https://docs.unstoppabledomains.com/openapi/partner/latest/)  for supported use cases.
+
+For `Partner API v3` access, please click `Request access to Partner API v3`. Our `Partner engineering team` team will be contacting you in shortly via email.
 
 :::warning
-Your API key is only intended for use on your backend servers. Any other usage could result in security risks and or your key being deactivated. Please refer to [Best Practices for Integrating Partner API](https://docs.unstoppabledomains.com/domain-distribution-and-management/guides/best-practices/#dont-use-your-secrets-in-the-frontend) for integrating with us.
-:::
-
-By default, you will have access to `Domain Resolution API`.
-
-If you wish to have access to `Partner API v3`, please click `Request access to Partner API v3`. Our `Partner engineering team` team will be contacting you in shortly via email.
-
-
-### SDK Key
-Refer to the [Javascript Resolution SDKs](https://github.com/unstoppabledomains/resolution)
-
-The key is only allowed to be used in Resolution SDKs to interact with EVM RPC providers to query on-chain data. The SDKs are unmaintained.
-
-### Legacy API Key
-Refer to [Domain Resolution](https://docs.unstoppabledomains.com/openapi/resolution/) and [Domain Distribution and Management Overview
-](https://docs.unstoppabledomains.com/domain-distribution-and-management/overview/#domain-distribution-and-management-overview) for supported use cases.
-
-Click `Reveal Key` under `Legacy API key` to acquire your API Key
-
-:::success Congratulations!
-You just registered to become an official Unstoppable Domains Partner.
+Your API key is only intended for use on your backend servers. Any other usage could result in security risks and or your key being deactivated.
 :::
 
 ## Step 4: Set up UD Sandbox
@@ -120,22 +102,22 @@ To build the Partner API integrations, switch to Sandbox mode. This mode allows 
 </figure>
 
 
-## Sandbox Environment URLs
+### Sandbox Environment URLs
 
-### Sandbox Website
+#### Sandbox Website
 
 ```bash
 https://ud-sandbox.com/
 ```
 
-### Sandbox API Endpoint
+#### Sandbox API Endpoint
 
 ```bash
 https://api.ud-sandbox.com/
 ```
 
 :::success Congratulations!
-You have successfully accessed and set up the Unstoppable Domains Sandbox Environment. Happy hacking!
+You just registered to become an official Unstoppable Domains Partner.
 :::
 
 <embed src="/snippets/_partner-survey-embed.md" />

--- a/resolution/quickstart/retrieve-an-api-key.md
+++ b/resolution/quickstart/retrieve-an-api-key.md
@@ -3,17 +3,99 @@ title: Resolution Service API | Unstoppable Domains Developer Portal
 description: This page provides a high-level overview of the Resolution Service API hosted by Unstoppable Domains.
 ---
 
-# Getting Started With the Resolution Service
+# Set up Resolution Service API Access Guide
 
-## Acquire an API Key
+This page explains the process for creating an account and applying to become an authorized partner for Unstoppable Domains.
 
-Before you can make any request to the Resolution Service API, you must acquire an API key from Unstoppable Domains. Please refer to this [document](https://docs.unstoppabledomains.com/domain-distribution-and-management/quickstart/retrieve-an-api-key/#set-up-partner-api-access-guide) to acquire an API key or email <partnerengineering@unstoppabledomains.com> to request an API key for your integration.
+## Step 1: Sign Up to Partner Dashboard
 
-:::info
-The API key provided by Unstoppable Domains is free to acquire (no cost to open source projects). However, storing the keys in a secret manager or environment variables for open-source projects like other third-party APIs is advisable.
+You must create an Unstoppable Domains Partner account in [Partner Dashboard](https://dashboard.auth.unstoppabledomains.com). You may **Login** using your existing Unstoppable Domains account information or **Sign Up** if you don’t already have an account.
+
+<figure>
+
+![Login or sign-up options for new partners](/images/partner-signup.png "#width=60%;")
+
+<figcaption>Login or sign-up options for new partners</figcaption>
+</figure>
+
+
+## Step 2: Setup Your First Application
+
+Let us know who you are by submitting your **Company name** and **Company type**
+
+<figure>
+
+![Submit company details](/images/submit-company-name.png "#width=60%;")
+
+<figcaption>Submit company details</figcaption>
+</figure>
+
+Navigate to [Clients Page](https://dashboard.auth.unstoppabledomains.com/clients) by clicking `Clients` at the top of the app. Read the `Partner API Terms` and submit your agreement.
+
+<figure>
+
+![Partner API Terms](/images/dashboard-client-page.png "#width=90%;")
+
+<figcaption>Partner API Terms</figcaption>
+</figure>
+
+Create your first client by clicking the `Create Client` button.
+
+<figure>
+
+![Create First Client](/images/dashboard-empty-client-page.png "#width=80%;")
+
+<figcaption>Create First Client</figcaption>
+</figure>
+
+Update your client information and click `Confirm Changes`
+
+<figure>
+
+![Update Client Information](/images/dashboard-update-client-info.png "#width=80%;")
+
+<figcaption>Update Client Information</figcaption>
+</figure>
+
+## Step 3: Obtain an API Key
+
+Navigate to the `API & SDK Panel` by clicking the `API & SDK` button.
+
+<figure>
+
+![API Panel](/images/dashboard-api-pannel.png "#width=80%;")
+
+<figcaption>API Panel</figcaption>
+</figure>
+
+Request one of the following keys depending on your current usage. You **might** be required to provide an email address for our partner engineering team to contact you if you originally signed up using a Wallet address such as MetaMask.
+
+<figure>
+
+![Email Requirement](/images/dashboard-email-requirement.png "#width=80%;")
+
+<figcaption>Email Requirement</figcaption>
+</figure>
+
+### API Key
+Refer to [Domain Resolution API](https://docs.unstoppabledomains.com/openapi/resolution/) for supported use cases.
+
+By default, you will have access to `Domain Resolution API`. You do not need to click on `Request access to Partner API v3`.
+
+:::warning
+Your API key is only intended for use on your backend servers. Any other usage could result in security risks and or your key being deactivated.
 :::
 
-## Authenticate Your Requests
+### SDK Key
+Refer to the [Javascript Resolution SDKs](https://github.com/unstoppabledomains/resolution)
+
+The key is only allowed to be used in Resolution SDKs to interact with EVM RPC providers to query on-chain data. 
+
+:::warning
+The SDKs are no longer maintained.
+:::
+
+## Step 4: Authenticate Your Requests
 
 The Resolution Service API uses `Bearer Tokens` to authorize requests with the API key gotten from Unstoppable Domains.
 
@@ -23,10 +105,12 @@ The Resolution Service API uses `Bearer Tokens` to authorize requests with the A
 | HTTP Authorization Scheme | bearer |
 | Bearer Format | a token provided by Unstoppable Domains |
 
-## Fork Our Postman Collection
+### Fork Our Postman Collection
 
 Unstoppable Domains offers a Postman collection that you can easily import into your workspace to quickly interact with the Resolution Service API.
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://god.gw.postman.com/run-collection/19507736-52bf9f35-1608-4dc4-a96d-e62682b59199?action=collection%2Ffork&collection-url=entityId%3D19507736-52bf9f35-1608-4dc4-a96d-e62682b59199%26entityType%3Dcollection%26workspaceId%3D6762865c-b510-4216-ba7f-45cd07f164c7#?env%5BResolution%20Service%20-%20Open%20API%5D=W3sia2V5IjoiYmFzZV91cmwiLCJ2YWx1ZSI6Imh0dHBzOi8vcmVzb2x2ZS51bnN0b3BwYWJsZWRvbWFpbnMuY29tIiwiZW5hYmxlZCI6dHJ1ZSwidHlwZSI6ImRlZmF1bHQiLCJzZXNzaW9uVmFsdWUiOiJodHRwczovL3Jlc29sdmUudW5zdG9wcGFibGVkb21haW5zLmNvbSIsInNlc3Npb25JbmRleCI6MH0seyJrZXkiOiJhcGlfa2V5IiwidmFsdWUiOiIiLCJlbmFibGVkIjp0cnVlLCJ0eXBlIjoic2VjcmV0Iiwic2Vzc2lvblZhbHVlIjoiIiwic2Vzc2lvbkluZGV4IjoxfV0=)
 
-
+:::success Congratulations!
+You just registered to become an official Unstoppable Domains Partner.
+:::


### PR DESCRIPTION
## What/Why/How?

The API key access guides for Partner API v3 and Domain Resolution have been updated to provide more accurate and relevant information to users. 

The Resolution API access guide originally said to email PE which doesnt need to happen and can be self-service.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
