### PR TITLE
[REG-1901] Remove `uns` dependency and its reference from `yarn.lock`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "ejs": "^3.1.10",
     "markdown-include": "^0.4.3",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3",
-    "uns": "https://github.com/unstoppabledomains/uns.git"
+    "typescript": "^5.8.3"
   },
   "resolutions": {
     "styled-components": "5.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15429,10 +15429,6 @@ unraw@^3.0.0:
   resolved "https://registry.yarnpkg.com/unraw/-/unraw-3.0.0.tgz#73443ed70d2ab09ccbac2b00525602d5991fbbe3"
   integrity sha512-08/DA66UF65OlpUDIQtbJyrqTR0jTAlJ+jsnkQ4jxR7+K5g5YG1APZKQSMCE1vqqmD+2pv6+IdEjmopFatacvg==
 
-"uns@https://github.com/unstoppabledomains/uns.git":
-  version "0.4.10"
-  resolved "https://github.com/unstoppabledomains/uns.git#762dee11a522a665656366733ffb5867bdc51927"
-
 unset-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"


### PR DESCRIPTION
## What/Why/How?
We’re planning to make the UNS repository private, which means all consumers of UNS must be configured to pull it as a private package.

From what I can see, the dev-docs stack installs UNS as a dev dependency but doesn’t actually use it. I’ve decided to remove it from the dependencies to simplify things.

Please let me know if you have any concerns.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
