### PR TITLE
[no ticket] fix: Feedback widget overlaps AI button

### DIFF
--- a/@theme/styles.css
+++ b/@theme/styles.css
@@ -210,6 +210,10 @@
     --video-aspect-ratio: calc(9/16);
 
     --md-content-max-width: 910px;
+
+    /* AI Assistant */
+    --ai-assistant-button-bottom: 80px;
+    --ai-assistant-button-right: 29px;
 }
 
 figure {

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -137,6 +137,11 @@ apis:
 mockServer:
   off: true
 
+aiAssistant:
+  hide: false
+  trigger:
+    hide: false
+
 links:
   - href: https://fonts.gstatic.com
     rel: preconnect


### PR DESCRIPTION
## What/Why/How?

The "Ask AI" button is overlapped by the "Feedback" widget which blocks it's use. 

<img width="230" height="163" alt="Screenshot 2025-12-05 at 1 29 59 PM" src="https://github.com/user-attachments/assets/c17ee04c-b116-4829-bb77-1e18afb1e84f" />


Force enabled the AI Assistant button and fixed styling

<img width="188" height="140" alt="Screenshot 2025-12-05 at 1 30 06 PM" src="https://github.com/user-attachments/assets/42379848-bf8d-4b83-8275-d91ea4dc92a8" />

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
