### PR TITLE
docs: remove auto-publish retention and credit exchange rate from Site Builder

### DIFF
--- a/features/ai-site-builder.md
+++ b/features/ai-site-builder.md
@@ -416,7 +416,6 @@ If your promo credits and account balance fully cover the purchase, no card paym
 | Image file size | 1.5 MB each |
 | Supported image formats | PNG, JPEG, JPG, WebP, GIF |
 | Conversation history | ~50 back-and-forth turns retained |
-| Auto-publish window | 30 days after setting up |
 
 ---
 

--- a/features/ai-site-builder.md
+++ b/features/ai-site-builder.md
@@ -327,8 +327,6 @@ If you find and purchase a domain from within the AI Site Builder (via the **Fin
 4. Once the domain is registered, your site is automatically published to it.
 5. You'll receive a confirmation email when the auto-publish is complete.
 
-The auto-publish mapping is stored for up to **30 days** from the time you set it up.
-
 ---
 
 ## AI Credits
@@ -361,8 +359,6 @@ Credit cost per message depends on the AI model:
 | Claude Opus | ~5 – 10 credits |
 
 The exact cost is calculated based on actual token usage (how much the AI reads and writes). Each assistant message in your chat shows its credit cost, so you always know what you spent.
-
-The exchange rate is **1 AI credit = $0.15 of AI model usage**.
 
 #### Publishing
 


### PR DESCRIPTION
## What/Why/How?

Removes two lines from the AI Site Builder docs that should not be published:
- The 30-day auto-publish mapping retention note
- The AI credit exchange rate (`1 AI credit = $0.15`)

## Reference

N/A

## Testing

Verified the surrounding content still reads correctly after removal.

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines