### PR TITLE
docs: add marketplace listings endpoint to Reseller API

### DIFF
--- a/apis/reseller/implementation-guide.md
+++ b/apis/reseller/implementation-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Implementation Guide | Unstoppable Domains Developer Portal
-description: Implementation details for domain search, registration, contact management, DNS management, webhooks, and lifecycle operations in the Reseller API
+description: Implementation details for domain search, registration, marketplace listings, contact management, DNS management, webhooks, and lifecycle operations in the Reseller API
 ---
 
 # Implementation Guide
@@ -231,6 +231,78 @@ curl -X POST "https://api.ud-sandbox.com/partner/v3/domains?\$preview=true" \
 ```
 
 The response includes the pricing breakdown and validates all fields without actually registering the domain.
+
+## Marketplace Listings
+
+The marketplace endpoint lets you browse domains listed for sale on the Unstoppable Domains secondary marketplace. This is useful for offering your users access to premium or previously registered domains that current owners have put up for sale.
+
+### Browsing Listings
+
+Retrieve a paginated list of marketplace listings filtered by TLD:
+
+```bash
+curl "https://api.ud-sandbox.com/partner/v3/marketplace/domains/listings?tlds=com&perPage=10&\$page=1" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```
+
+The `tlds` parameter is required and accepts one or more TLD extensions. You can also pass a search query using the `q` parameter to filter by domain name:
+
+```bash
+curl "https://api.ud-sandbox.com/partner/v3/marketplace/domains/listings?tlds=com&q=crypto&orderBy=price&orderDirection=ASC" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```
+
+### Response Structure
+
+Each listing in the response includes:
+
+| Field | Description |
+|-------|-------------|
+| `domain` | The domain name listed for sale |
+| `status` | Current listing status |
+| `listPrice.usdCents` | The asking price in USD cents |
+| `payout.address` | Wallet address designated to receive the sale proceeds |
+| `owner.address` | Wallet address of the current domain owner |
+| `expiresAt` | Unix timestamp when the listing expires (if set) |
+
+Example response:
+
+```json
+{
+  "items": [
+    {
+      "domain": "premium.com",
+      "status": "ACTIVE",
+      "listPrice": {
+        "usdCents": 500000
+      },
+      "payout": {
+        "address": "0x1234...abcd"
+      },
+      "owner": {
+        "address": "0x5678...efgh"
+      },
+      "expiresAt": 1735689600
+    }
+  ],
+  "next": {
+    "page": 2,
+    "limit": 10
+  }
+}
+```
+
+### Sorting and Pagination
+
+Use `orderBy` and `orderDirection` to control result ordering:
+
+| `orderBy` | Description |
+|-----------|-------------|
+| `price` | Sort by listing price |
+| `name` | Sort alphabetically by domain name |
+| `listedAt` | Sort by when the domain was listed |
+
+Results are paginated. Use `$page` (1-indexed) and `perPage` (1–100) to navigate. The `next` field provides the parameters for the next page, or `null` if you are on the last page.
 
 ## Contact Management
 

--- a/apis/reseller/openapi.yaml
+++ b/apis/reseller/openapi.yaml
@@ -12,6 +12,7 @@ info:
     - **Domain Registration**: Register domains with full control over registration period, contacts, and initial DNS configuration
     - **DNS Management**: Create, update and delete DNS records for your domains
     - **Domain Lifecycle**: Manage renewals, transfers, contacts, and domain flags through a simple API interface
+    - **Marketplace**: Browse secondary marketplace listings to find premium domains available for purchase from existing owners
 
     For access, authentication, environments, and your first request, start with the [Quick Start](/apis/reseller/quick-start).
 
@@ -82,6 +83,10 @@ tags:
 
     All hosting configurations require SSL certificate provisioning. When a configuration is created or updated, the `certificateStatus` field will be `PENDING` until the certificate is issued and active. This process typically completes within a few minutes but may take longer in some cases.
   x-displayName: Hosting
+- name: marketplace
+  description: |
+    Browse and search the Unstoppable Domains secondary marketplace. Retrieve paginated listings of domains available for purchase from existing owners, with filtering by TLD and sorting options.
+  x-displayName: Marketplace
 - name: account
   description: Manage your account details, authentication tokens, and webhook subscriptions.
   x-displayName: Account
@@ -96,6 +101,9 @@ x-tagGroups:
   - domain-transfers
   - domain-flags
   - domain-contacts
+- name: Marketplace
+  tags:
+  - marketplace
 - name: Discovery
   tags:
   - pricing
@@ -2565,6 +2573,98 @@ paths:
       summary: Get TLD details
       description: |
         Retrieve details for a specific top-level domain (TLD) including its naming system and registration availability.
+  /marketplace/domains/listings:
+    get:
+      operationId: getMarketplaceDomainsListings
+      parameters:
+      - name: q
+        required: false
+        in: query
+        description: Search query to filter listings by domain name. Supports partial matching.
+        schema:
+          type: string
+      - name: tlds
+        required: true
+        in: query
+        description: One or more TLD extensions to filter listings (e.g., `com`, `xyz`). At least one TLD must be provided.
+        schema:
+          uniqueItems: true
+          default: []
+          type: array
+          items:
+            type: string
+      - name: orderBy
+        required: false
+        in: query
+        description: Field to sort results by.
+        schema:
+          type: string
+          enum:
+          - price
+          - name
+          - listedAt
+      - name: orderDirection
+        required: false
+        in: query
+        description: Sort direction. Defaults to ascending.
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: perPage
+        required: false
+        in: query
+        description: Number of results per page (1–100).
+        schema:
+          minimum: 1
+          maximum: 100
+          type: number
+      - name: $page
+        required: false
+        in: query
+        description: Page number for pagination (1-indexed).
+        schema:
+          minimum: 1
+          type: number
+      responses:
+        '200':
+          description: Paginated list of marketplace domain listings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketplaceDomainsListingsResponse'
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      tags:
+      - marketplace
+      summary: List marketplace domain listings
+      description: |
+        Retrieve a paginated list of domains currently listed for sale on the Unstoppable Domains secondary marketplace. Use this endpoint to browse available domains, filter by TLD, and sort by price, name, or listing date.
+
+        Results are paginated — use the `$page` and `perPage` parameters to navigate through results.
 webhooks:
   OPERATION_FINISHED:
     post:
@@ -5271,5 +5371,67 @@ components:
       - '@type'
       - type
       - data
+    MarketplaceDomainsListingListPriceResponse:
+      type: object
+      properties:
+        usdCents:
+          type: number
+          description: Listing price in USD cents
+      required:
+      - usdCents
+    MarketplaceDomainsListingPayoutResponse:
+      type: object
+      properties:
+        address:
+          type: string
+          description: Wallet address designated to receive the payout
+      required:
+      - address
+    MarketplaceDomainsListingOwnerResponse:
+      type: object
+      properties:
+        address:
+          type: string
+          description: Wallet address of the domain owner
+      required:
+      - address
+    MarketplaceDomainsListingItemResponse:
+      type: object
+      properties:
+        domain:
+          type: string
+          description: The domain name listed for sale
+        status:
+          type: string
+          description: Current listing status
+        listPrice:
+          $ref: '#/components/schemas/MarketplaceDomainsListingListPriceResponse'
+        payout:
+          $ref: '#/components/schemas/MarketplaceDomainsListingPayoutResponse'
+        owner:
+          $ref: '#/components/schemas/MarketplaceDomainsListingOwnerResponse'
+        expiresAt:
+          type: number
+          description: Unix timestamp when the listing expires (if applicable)
+      required:
+      - domain
+      - status
+      - listPrice
+      - payout
+      - owner
+    MarketplaceDomainsListingsResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketplaceDomainsListingItemResponse'
+        next:
+          nullable: true
+          allOf:
+          - $ref: '#/components/schemas/PaginatedListResponseNext'
+      required:
+      - items
+      - next
 security:
 - bearer: []


### PR DESCRIPTION
## Summary

- Add `GET /marketplace/domains/listings` endpoint to the Reseller API OpenAPI spec with query parameters for search, TLD filtering, sorting, and pagination
- Add corresponding response schemas (`MarketplaceDomainsListingsResponse`, `MarketplaceDomainsListingItemResponse`, etc.)
- Add `marketplace` tag and tag group to the API reference
- Add "Marketplace Listings" section to the implementation guide with curl examples, response structure docs, and sorting/pagination guidance

## Test plan

- [ ] Verify the OpenAPI spec renders correctly in the docs portal with the new Marketplace section
- [ ] Confirm the `/marketplace/domains/listings` endpoint appears under the Marketplace tag group
- [ ] Check that the response schema displays correctly (no `pagination` object, only `next` for paging)
- [ ] Verify implementation guide marketplace section renders with proper formatting and examples