### PR TITLE
[ECW-8227] docs(reseller): rename /account/domains to /account/domain-registrations

### DIFF
--- a/apis/reseller/openapi.yaml
+++ b/apis/reseller/openapi.yaml
@@ -1807,9 +1807,9 @@ paths:
         Filter by `type` to narrow results to specific balance-change categories. Pass `groupBy=operationId` to receive transactions grouped by their originating operation, with each group reporting the total amount and associated domain.
 
         Results are paginated — use the `$cursor` parameter to retrieve subsequent pages.
-  /account/domains:
+  /account/domain-registrations:
     get:
-      operationId: getAccountDomains
+      operationId: getAccountDomainRegistrations
       parameters:
       - name: $cursor
         required: false


### PR DESCRIPTION
## Summary

Renames the account-scoped domain list endpoint in the Reseller API spec to match [registrar-platform#3004](https://github.com/unstoppabledomains/registrar-platform/pull/3004), which renamed the route/controller layer from `/account/domains` to `/account/domain-registrations`.

## Changes

In `apis/reseller/openapi.yaml`:
- Path `/account/domains` → `/account/domain-registrations`
- `operationId: getAccountDomains` → `getAccountDomainRegistrations` (matches the renamed handler)

### Intentionally unchanged (matching the upstream PR, which kept the data model and wire layer untouched)
- The wire `@type` value `unstoppabledomains.com/partner.v3.AccountDomain`
- Schema names (`AccountDomainListResponse`, `AccountDomainResponse`, `AccountDomainStatus`)
- The human-facing `summary`/`description` (the returned data — domains in your account — is unchanged)

## Note

Per the upstream PR, this is a **breaking route change with no backward-compatible alias** — any caller hitting the old `GET /account/domains` will now receive a 404.