### PR TITLE
[ECW-8381] docs(reseller): add registryCreatedDate to domain registration responses

### DIFF
--- a/apis/reseller/openapi.yaml
+++ b/apis/reseller/openapi.yaml
@@ -3172,6 +3172,8 @@ components:
           - TOKEN2022
         pricing:
           $ref: '#/components/schemas/DomainPostRegistrationPricingResponse'
+        registryCreatedDate:
+          type: string
         expirationDate:
           type: string
         expirationGracePeriodDate:
@@ -3614,6 +3616,8 @@ components:
           $ref: '#/components/schemas/DomainRegistrationStatus'
         icann:
           $ref: '#/components/schemas/DomainRegistrationIcannResponse'
+        registryCreatedDate:
+          type: string
         expirationDate:
           type: string
         expirationGracePeriodDate:


### PR DESCRIPTION
## Summary

Documents the new optional `registryCreatedDate` field added to the Reseller (Partner) API in [registrar-platform#3037](https://github.com/unstoppabledomains/registrar-platform/pull/3037).

The field is an ISO-8601 timestamp of the registry "created at" date, surfaced in domain registration data (e.g. `GET /domains?$expand=registration`). It is omitted for web3-only domains with no registry data.

## Related Issue

[ECW-8381](https://linear.app/unstoppable-domains/issue/ECW-8381)

## Changes

Added `registryCreatedDate` to both registration response schemas in `apis/reseller/openapi.yaml`, mirroring the upstream DTO ordering (just before `expirationDate`) and the bare `type: string` style of sibling date fields:

- `DomainRegistrationResponse`
- `DomainRegistrationMinimalResponse`

The field is optional/additive — fully backwards compatible, no `required` changes.

## Notes

- The upstream `api` repo generated spec is the source of truth; this keeps the published Reseller API reference in sync in the meantime. Field name/placement should be confirmed against the generated spec once it lands.
- The reseller markdown guides reference `$expand=registration` generically without enumerating response fields, so no changes were needed there.
- Spec lints cleanly with `@redocly/cli`.